### PR TITLE
Change the database used from leveldb to mdbx.

### DIFF
--- a/accounts/manager.go
+++ b/accounts/manager.go
@@ -54,8 +54,6 @@ type Manager struct {
 	newBackends chan newBackendEvent       // Incoming backends to be tracked by the manager
 	wallets     []Wallet                   // Cache of all wallets from all registered backends
 
-	feed event.Event // Wallet feed notifying of arrivals/departures
-
 	quit chan chan error
 	term chan struct{} // Channel is closed upon termination of the update loop
 	lock sync.RWMutex
@@ -132,29 +130,31 @@ func (am *Manager) update() {
 	// Loop until termination
 	for {
 		select {
-		case event := <-am.updates:
+		case walletEvent := <-am.updates:
 			// Wallet event arrived, update local cache
 			am.lock.Lock()
-			switch event.Kind {
+			switch walletEvent.Kind {
 			case WalletArrived:
-				am.wallets = merge(am.wallets, event.Wallet)
+				am.wallets = merge(am.wallets, walletEvent.Wallet)
 			case WalletDropped:
-				am.wallets = drop(am.wallets, event.Wallet)
+				am.wallets = drop(am.wallets, walletEvent.Wallet)
 			}
 			am.lock.Unlock()
 
 			// Notify any listeners of the event
-			am.feed.Send(event)
-		case event := <-am.newBackends:
+
+			//am.feed.Send(&walletEvent)
+			event.GlobalEvent.Send(&walletEvent)
+		case backendEvent := <-am.newBackends:
 			am.lock.Lock()
 			// Update caches
-			backend := event.backend
+			backend := backendEvent.backend
 			am.wallets = merge(am.wallets, backend.Wallets()...)
 			am.updaters = append(am.updaters, backend.Subscribe(am.updates))
 			kind := reflect.TypeOf(backend)
 			am.backends[kind] = append(am.backends[kind], backend)
 			am.lock.Unlock()
-			close(event.processed)
+			close(backendEvent.processed)
 		case errc := <-am.quit:
 			// Manager terminating, return
 			errc <- nil
@@ -238,7 +238,7 @@ func (am *Manager) Find(account Account) (Wallet, error) {
 // Subscribe creates an async subscription to receive notifications when the
 // manager detects the arrival or departure of a wallet from any of its backends.
 func (am *Manager) Subscribe(sink chan<- WalletEvent) event.Subscription {
-	return am.feed.Subscribe(sink)
+	return event.GlobalEvent.Subscribe(sink)
 }
 
 // merge is a sorted analogue of append for wallets, where the ordering of the

--- a/internal/p2p/discovery.go
+++ b/internal/p2p/discovery.go
@@ -8,6 +8,7 @@ import (
 	"github.com/amazechain/amc/internal/p2p/enr"
 	"github.com/amazechain/amc/utils"
 	"net"
+	"path/filepath"
 	"time"
 
 	"github.com/libp2p/go-libp2p/core/network"
@@ -174,7 +175,7 @@ func (s *Service) createLocalNode(
 	ipAddr net.IP,
 	udpPort, tcpPort int,
 ) (*enode.LocalNode, error) {
-	db, err := enode.OpenDB("")
+	db, err := enode.OpenDB(filepath.Join(s.cfg.DataDir, "nodedata"), "")
 	if err != nil {
 		return nil, errors.Wrap(err, "could not open node's peer database")
 	}

--- a/internal/p2p/enode/nodedb.go
+++ b/internal/p2p/enode/nodedb.go
@@ -88,7 +88,7 @@ type DB struct {
 // OpenDB opens a node database for storing and retrieving infos about known peers in the
 // network. If no path is given an in-memory, temporary database is constructed.
 func OpenDB(path string, tmpDir string) (*DB, error) {
-	logger := log.New() //TODO: move higher
+	logger := log.New()
 	if path == "" {
 		return newMemoryDB(logger, tmpDir)
 	}


### PR DESCRIPTION
Change the database used from leveldb to mdbx.And because the parameters of the new function and the original function are different, modify the statements in discovery.go that call the database open function synchronously.

eliminate bug：adding or removing the files saving account information in keystore folder will cause panic and program interruption； 
Remove the redundant attribute feed of the structure Manager and suppress warnings about variable name conflicts